### PR TITLE
Rename db workflow

### DIFF
--- a/database/db_init.go
+++ b/database/db_init.go
@@ -38,52 +38,49 @@ const (
 type databaseInitializer struct {
 	Driver           DatabaseDriver
 	Loader           DatabaseLoader
-	ConnectionString string
-	Env              *DatabaseConfig
+	DatabaseConfig              *DatabaseConfig
+}
+
+func (d *databaseInitializer) load() (*gorm.DB,error){
+	cnf := d.DatabaseConfig
+	return d.Loader.LoadDatabase(cnf)
 }
 
 // TODO: Delete driverStr from the method signature.
 //
 //	This field will be read from .env file
-func InitializeDatabaseDriver(env *DatabaseConfig) databaseInitializer {
-	driverStr := strings.ToLower(env.DatabaseType)
+func InitializeDatabaseDriver(databaseConfig *DatabaseConfig) databaseInitializer {
+	driverStr := strings.ToLower(databaseConfig.DatabaseType)
 	var systemDriver DatabaseDriver
 	var loader DatabaseLoader = NotImplementedLoader{}
-	var connectionString string
-	var err error
 	switch driverStr {
 	case "mysql":
 		systemDriver = MySql
 		loader = MySqlLoader{}
-		err, connectionString = loader.BuildDsn(env)
+		
 	case "mariadb":
 		systemDriver = MariaDb
 		loader = MySqlLoader{}
-		err, connectionString = loader.BuildDsn(env)
+		
 	case "oracle":
 		systemDriver = Oracle
-		err, connectionString = loader.BuildDsn(env)
+		
 	case "postgres":
 		systemDriver = Postgres
 		loader = PostgresLoader{}
-		err, connectionString = loader.BuildDsn(env)
+		
 	case "sqlserver":
 		systemDriver = SqlServer
 	case "sqlite3":
 		systemDriver = Sqlite3
 		loader = SqliteLoader{}
-		err, connectionString = loader.BuildDsn(env)
-	}
-
-	if err != nil {
-		panic(err)
+		
 	}
 
 	return databaseInitializer{
 		Driver:           systemDriver,
-		ConnectionString: connectionString,
 		Loader:           loader,
-		Env:              env,
+		DatabaseConfig:              databaseConfig,
 	}
 }
 
@@ -91,7 +88,7 @@ func InitializeDatabaseDriver(env *DatabaseConfig) databaseInitializer {
 // that will connect the app to the database.
 func (initializer *databaseInitializer) InitDatabase() *gorm.DB {
 	var db *gorm.DB
-	db, err := initializer.Loader.LoadDatabase(initializer.ConnectionString)
+	db, err := initializer.load()
 	if err != nil {
 		panic(err)
 	}

--- a/database/db_init.go
+++ b/database/db_init.go
@@ -91,8 +91,6 @@ func InitializeDatabaseDriver(env *DatabaseConfig) databaseInitializer {
 // that will connect the app to the database.
 func (initializer *databaseInitializer) InitDatabase() *gorm.DB {
 	var db *gorm.DB
-	// Read env variables: driver + connection
-
 	db, err := initializer.Loader.LoadDatabase(initializer.ConnectionString)
 	if err != nil {
 		panic(err)
@@ -106,13 +104,3 @@ func GetDatabase() *gorm.DB {
 	initializer := InitializeDatabaseDriver(env)
 	return initializer.InitDatabase()
 }
-
-/*
-	Reglas:
-	1. Utilizar solo un método que cargue la base de datos configurada con el entorno -InitDatabase-
-
-	Pasos:
-	1. Carga del .env
-	2. Connection to database -LoaderDatabase
-
-*/

--- a/database/db_init.go
+++ b/database/db_init.go
@@ -30,7 +30,7 @@ const (
 	Oracle    DatabaseDriver = "oracle"
 	SqlServer DatabaseDriver = "sqlserver"
 	MariaDb   DatabaseDriver = "mariadb"
-	Sqlite3  DatabaseDriver = "sqlite3"
+	Sqlite3   DatabaseDriver = "sqlite3"
 )
 
 // Will handle the connection to the database
@@ -39,13 +39,13 @@ type databaseInitializer struct {
 	Driver           DatabaseDriver
 	Loader           DatabaseLoader
 	ConnectionString string
-	Env				 *Env
+	Env              *DatabaseConfig
 }
 
-
 // TODO: Delete driverStr from the method signature.
-//		 This field will be read from .env file
-func InitializeDatabaseDriver(env *Env) databaseInitializer {
+//
+//	This field will be read from .env file
+func InitializeDatabaseDriver(env *DatabaseConfig) databaseInitializer {
 	driverStr := strings.ToLower(env.DatabaseType)
 	var systemDriver DatabaseDriver
 	var loader DatabaseLoader = NotImplementedLoader{}
@@ -78,13 +78,12 @@ func InitializeDatabaseDriver(env *Env) databaseInitializer {
 	if err != nil {
 		panic(err)
 	}
-	
-	
+
 	return databaseInitializer{
 		Driver:           systemDriver,
 		ConnectionString: connectionString,
 		Loader:           loader,
-		Env: 			  env,
+		Env:              env,
 	}
 }
 
@@ -93,7 +92,7 @@ func InitializeDatabaseDriver(env *Env) databaseInitializer {
 func (initializer *databaseInitializer) InitDatabase() *gorm.DB {
 	var db *gorm.DB
 	// Read env variables: driver + connection
-	
+
 	db, err := initializer.Loader.LoadDatabase(initializer.ConnectionString)
 	if err != nil {
 		panic(err)
@@ -101,12 +100,13 @@ func (initializer *databaseInitializer) InitDatabase() *gorm.DB {
 	return db
 }
 
-func GetDatabase() (*gorm.DB) {
+func GetDatabase() *gorm.DB {
 	godotenv.Load(".env")
 	env := LoadDatabaseEnvVariables(".env")
 	initializer := InitializeDatabaseDriver(env)
 	return initializer.InitDatabase()
 }
+
 /*
 	Reglas:
 	1. Utilizar solo un método que cargue la base de datos configurada con el entorno -InitDatabase-
@@ -114,5 +114,5 @@ func GetDatabase() (*gorm.DB) {
 	Pasos:
 	1. Carga del .env
 	2. Connection to database -LoaderDatabase
-	
+
 */

--- a/database/db_init.go
+++ b/database/db_init.go
@@ -30,7 +30,7 @@ const (
 	Oracle    DatabaseDriver = "oracle"
 	SqlServer DatabaseDriver = "sqlserver"
 	MariaDb   DatabaseDriver = "mariadb"
-	Sqlite3   DatabaseDriver = "sqlite3"
+	Sqlite3   DatabaseDriver = "sqlite"
 )
 
 // Will handle the connection to the database
@@ -41,14 +41,14 @@ type databaseInitializer struct {
 	DatabaseConfig              *DatabaseConfig
 }
 
+
 func (d *databaseInitializer) load() (*gorm.DB,error){
 	cnf := d.DatabaseConfig
 	return d.Loader.LoadDatabase(cnf)
 }
 
-// TODO: Delete driverStr from the method signature.
-//
-//	This field will be read from .env file
+// Depending on the database config, usually read from a .env file,
+// the correct DatabaseLoader will be allocated.
 func InitializeDatabaseDriver(databaseConfig *DatabaseConfig) databaseInitializer {
 	driverStr := strings.ToLower(databaseConfig.DatabaseType)
 	var systemDriver DatabaseDriver
@@ -71,7 +71,7 @@ func InitializeDatabaseDriver(databaseConfig *DatabaseConfig) databaseInitialize
 		
 	case "sqlserver":
 		systemDriver = SqlServer
-	case "sqlite3":
+	case "sqlite": 
 		systemDriver = Sqlite3
 		loader = SqliteLoader{}
 		
@@ -85,7 +85,8 @@ func InitializeDatabaseDriver(databaseConfig *DatabaseConfig) databaseInitialize
 }
 
 // This method from databaseInitializer will gracefully handle the driver
-// that will connect the app to the database.
+// that will connect the app to the database. 
+// It needs a DatabaseConfig object to work
 func (initializer *databaseInitializer) InitDatabase() *gorm.DB {
 	var db *gorm.DB
 	db, err := initializer.load()
@@ -95,6 +96,12 @@ func (initializer *databaseInitializer) InitDatabase() *gorm.DB {
 	return db
 }
 
+// Entrypoint for creating a Database connection
+// It uses the required .env file located in the root directory.
+// 
+// The magic of loading different kind of databases resides in the
+// InitializeDatabaseDriver() method, which loads the correct driver
+//
 func GetDatabase() *gorm.DB {
 	godotenv.Load(".env")
 	env := LoadDatabaseConfigFromEnv(".env")

--- a/database/db_init.go
+++ b/database/db_init.go
@@ -102,7 +102,7 @@ func (initializer *databaseInitializer) InitDatabase() *gorm.DB {
 
 func GetDatabase() *gorm.DB {
 	godotenv.Load(".env")
-	env := LoadDatabaseEnvVariables(".env")
+	env := LoadDatabaseConfigFromEnv(".env")
 	initializer := InitializeDatabaseDriver(env)
 	return initializer.InitDatabase()
 }

--- a/database/db_init_mysql_test.go
+++ b/database/db_init_mysql_test.go
@@ -41,7 +41,6 @@ func TestMySqlInitialization(t *testing.T) {
 		t.Errorf("TestMySqlInitialization failed. loader type is %T", l)
 	}
 
-	t.Log(initializer.ConnectionString)
 
 }
 

--- a/database/db_init_mysql_test.go
+++ b/database/db_init_mysql_test.go
@@ -10,7 +10,7 @@ var mysqlDriver string = "mysql"
 var sqliteDriver string = "sqlite3"
 
 func TestNotImplementedInitialization(t *testing.T) {
-	env := &Env{
+	env := &DatabaseConfig{
 		DatabaseType: testDriver,
 	}
 	initializer := InitializeDatabaseDriver(env)
@@ -24,13 +24,13 @@ func TestNotImplementedInitialization(t *testing.T) {
 }
 
 func TestMySqlInitialization(t *testing.T) {
-	env := &Env{
-		DatabaseType: mysqlDriver,
-		DatabaseUrl: "19.9.9.22",
-		DatabasePort: "9888",
-		DatabaseUser: "juser",
+	env := &DatabaseConfig{
+		DatabaseType:     mysqlDriver,
+		DatabaseUrl:      "19.9.9.22",
+		DatabasePort:     "9888",
+		DatabaseUser:     "juser",
 		DatabasePassword: "pwd",
-		DatabaseName: "db",
+		DatabaseName:     "db",
 	}
 	initializer := InitializeDatabaseDriver(env)
 
@@ -61,11 +61,11 @@ func TestMySql_Env_Connection_String(t *testing.T) {
 }
 
 func Test_Sqlite3_Initialization(t *testing.T) {
-env := &Env{
+	env := &DatabaseConfig{
 		DatabaseType: sqliteDriver,
 	}
 	initializer := InitializeDatabaseDriver(env)
-	
+
 	loader := initializer.Loader
 	if l, ok := loader.(SqliteLoader); ok {
 		t.Log("TestMySqlInitialization PASSED")

--- a/database/db_init_mysql_test.go
+++ b/database/db_init_mysql_test.go
@@ -7,7 +7,7 @@ import (
 var testConnStr string = "test@connectionstring:9999/test-db"
 var testDriver string = "TEST"
 var mysqlDriver string = "mysql"
-var sqliteDriver string = "sqlite3"
+var sqliteDriver string = "sqlite"
 
 func TestNotImplementedInitialization(t *testing.T) {
 	env := &DatabaseConfig{
@@ -62,9 +62,9 @@ func TestMySql_Env_Connection_String(t *testing.T) {
 func Test_Sqlite3_Initialization(t *testing.T) {
 	env := &DatabaseConfig{
 		DatabaseType: sqliteDriver,
+		DatabaseName: "db",
 	}
 	initializer := InitializeDatabaseDriver(env)
-
 	loader := initializer.Loader
 	if l, ok := loader.(SqliteLoader); ok {
 		t.Log("TestMySqlInitialization PASSED")

--- a/database/db_init_mysql_test.go
+++ b/database/db_init_mysql_test.go
@@ -46,7 +46,7 @@ func TestMySqlInitialization(t *testing.T) {
 }
 
 func TestMySql_Env_Connection_String(t *testing.T) {
-	env := LoadDatabaseEnvVariables("./.mysql")
+	env := LoadDatabaseConfigFromEnv("./.mysql")
 	initializer := InitializeDatabaseDriver(env)
 	loader := initializer.Loader
 

--- a/database/env.go
+++ b/database/env.go
@@ -1,20 +1,20 @@
 package database
 
-import(
+import (
 	"os"
 	"github.com/joho/godotenv"
 )
 
-type Env struct {
-	DatabaseType string
-	DatabaseUrl string
-	DatabaseUser string
+type DatabaseConfig struct {
+	DatabaseType     string
+	DatabaseUrl      string
+	DatabaseUser     string
 	DatabasePassword string
-	DatabasePort string
-	DatabaseName string
+	DatabasePort     string
+	DatabaseName     string
 }
 
-func LoadDatabaseEnvVariables(path string) *Env {
+func LoadDatabaseEnvVariables(path string) *DatabaseConfig {
 	godotenv.Load(path)
 	dbType := os.Getenv("DATABASE_TYPE")
 	url := os.Getenv("DATABASE_URL")
@@ -22,13 +22,13 @@ func LoadDatabaseEnvVariables(path string) *Env {
 	user := os.Getenv("DATABASE_USER")
 	pwd := os.Getenv("DATABASE_PASSWORD")
 	dbName := os.Getenv("DATABASE_NAME")
-	return &Env{
-		DatabaseType: dbType,
-		DatabaseUrl: url,
-		DatabaseUser: user,
+	return &DatabaseConfig{
+		DatabaseType:     dbType,
+		DatabaseUrl:      url,
+		DatabaseUser:     user,
 		DatabasePassword: pwd,
-		DatabasePort: port,
-		DatabaseName: dbName,
+		DatabasePort:     port,
+		DatabaseName:     dbName,
 	}
-						
+
 }

--- a/database/env.go
+++ b/database/env.go
@@ -2,6 +2,7 @@ package database
 
 import (
 	"os"
+
 	"github.com/joho/godotenv"
 )
 
@@ -14,7 +15,7 @@ type DatabaseConfig struct {
 	DatabaseName     string
 }
 
-func LoadDatabaseEnvVariables(path string) *DatabaseConfig {
+func LoadDatabaseConfigFromEnv(path string) *DatabaseConfig {
 	godotenv.Load(path)
 	dbType := os.Getenv("DATABASE_TYPE")
 	url := os.Getenv("DATABASE_URL")

--- a/database/interface.go
+++ b/database/interface.go
@@ -19,8 +19,8 @@ import (
 )
 
 type DatabaseLoader interface {
-	LoadDatabase(connectionString string) (*gorm.DB, error)
-	BuildDsn(env *DatabaseConfig) (error, string)
+	LoadDatabase(databaseConfig *DatabaseConfig) (*gorm.DB, error)
+	BuildDsn(databaseConfig *DatabaseConfig) (error, string)
 	// Testing
 	BuildDsnFromEnv(path string) (error, string)
 }

--- a/database/interface.go
+++ b/database/interface.go
@@ -15,12 +15,12 @@
 package database
 
 import (
-  "gorm.io/gorm"
+	"gorm.io/gorm"
 )
 
 type DatabaseLoader interface {
 	LoadDatabase(connectionString string) (*gorm.DB, error)
-	BuildDsn(env *Env) (error, string)
+	BuildDsn(env *DatabaseConfig) (error, string)
 	// Testing
 	BuildDsnFromEnv(path string) (error, string)
 }

--- a/database/mysql.go
+++ b/database/mysql.go
@@ -26,7 +26,11 @@ import (
 type MySqlLoader struct {
 }
 
-func (m MySqlLoader) LoadDatabase(connectionString string) (*gorm.DB, error) {
+func (m MySqlLoader) LoadDatabase(databaseConfig *DatabaseConfig) (*gorm.DB, error) {
+	err, connectionString := m.BuildDsn(databaseConfig)
+	if err != nil {
+		panic(err)
+	}
 	return gorm.Open(mysql.Open(connectionString), &gorm.Config{})
 }
 

--- a/database/mysql.go
+++ b/database/mysql.go
@@ -16,10 +16,11 @@ package database
 
 import (
 	"fmt"
+	"regexp"
+
 	"github.com/storage-system/database/patterns"
 	"gorm.io/driver/mysql"
 	"gorm.io/gorm"
-	"regexp"
 )
 
 type MySqlLoader struct {
@@ -29,12 +30,12 @@ func (m MySqlLoader) LoadDatabase(connectionString string) (*gorm.DB, error) {
 	return gorm.Open(mysql.Open(connectionString), &gorm.Config{})
 }
 
-func (m MySqlLoader) buildDsnFromEnvStruct(env *Env) string {
+func (m MySqlLoader) buildDsnFromEnvStruct(env *DatabaseConfig) string {
 	return env.DatabaseUser + ":" + env.DatabasePassword + "@" + "tcp(" + env.DatabaseUrl + ":" + env.DatabasePort + ")" + "/" + env.DatabaseName
 
 }
 
-func (m MySqlLoader) BuildDsn(env *Env) (error, string) {
+func (m MySqlLoader) BuildDsn(env *DatabaseConfig) (error, string) {
 
 	mysqlPattern := patterns.CreateDSNPatterns().MySQL
 

--- a/database/mysql.go
+++ b/database/mysql.go
@@ -53,7 +53,7 @@ func (m MySqlLoader) BuildDsn(env *DatabaseConfig) (error, string) {
 // Testing
 func (m MySqlLoader) BuildDsnFromEnv(path string) (error, string) {
 	fmt.Printf("MysqlLoader BuildDsnFromEnv %s\n", path)
-	env := LoadDatabaseEnvVariables(path)
+	env := LoadDatabaseConfigFromEnv(path)
 	if len(env.DatabaseUrl) == 0 || len(env.DatabaseUrl) == 0 {
 		panic(fmt.Errorf("Env file not loaded"))
 	}

--- a/database/not_implemented.go
+++ b/database/not_implemented.go
@@ -15,8 +15,9 @@
 package database
 
 import (
-  	"gorm.io/gorm"
 	"fmt"
+
+	"gorm.io/gorm"
 )
 
 type NotImplementedLoader struct {
@@ -26,11 +27,10 @@ func (n NotImplementedLoader) LoadDatabase(connectionString string) (*gorm.DB, e
 	return nil, fmt.Errorf("not implemented driver")
 }
 
-func (m NotImplementedLoader) BuildDsn(env *Env) (error, string) {
+func (m NotImplementedLoader) BuildDsn(env *DatabaseConfig) (error, string) {
 	return fmt.Errorf("Not implemented driver"), ""
 }
 
-func (m NotImplementedLoader) BuildDsnFromEnv(path string)(error, string){
+func (m NotImplementedLoader) BuildDsnFromEnv(path string) (error, string) {
 	return fmt.Errorf("Not implemented driver"), ""
 }
-

--- a/database/not_implemented.go
+++ b/database/not_implemented.go
@@ -23,7 +23,7 @@ import (
 type NotImplementedLoader struct {
 }
 
-func (n NotImplementedLoader) LoadDatabase(connectionString string) (*gorm.DB, error) {
+func (n NotImplementedLoader) LoadDatabase(databaseConfig *DatabaseConfig) (*gorm.DB, error) {
 	return nil, fmt.Errorf("not implemented driver")
 }
 

--- a/database/postgres.go
+++ b/database/postgres.go
@@ -16,23 +16,22 @@ package database
 
 import (
 	"gorm.io/driver/postgres" // Sqlite driver based on CGO
-  "gorm.io/gorm"
+	"gorm.io/gorm"
 )
 
 type PostgresLoader struct{}
 
 func (m PostgresLoader) LoadDatabase(connectionString string) (*gorm.DB, error) {
 	// dsn := "host=localhost user=gorm password=gorm dbname=gorm port=9920 sslmode=disable TimeZone=Asia/Shanghai"
-	return  gorm.Open(postgres.Open(connectionString), &gorm.Config{})
+	return gorm.Open(postgres.Open(connectionString), &gorm.Config{})
 
 }
-func (m PostgresLoader) BuildDsn(env *Env) (error, string) {
+func (m PostgresLoader) BuildDsn(env *DatabaseConfig) (error, string) {
 	return nil, ""
 
 }
 
-func (m PostgresLoader) BuildDsnFromEnv(path string)(error, string){
-		return nil, ""
+func (m PostgresLoader) BuildDsnFromEnv(path string) (error, string) {
+	return nil, ""
 
 }
-

--- a/database/postgres.go
+++ b/database/postgres.go
@@ -21,8 +21,12 @@ import (
 
 type PostgresLoader struct{}
 
-func (m PostgresLoader) LoadDatabase(connectionString string) (*gorm.DB, error) {
+func (m PostgresLoader) LoadDatabase(databaseConfig *DatabaseConfig) (*gorm.DB, error) {
 	// dsn := "host=localhost user=gorm password=gorm dbname=gorm port=9920 sslmode=disable TimeZone=Asia/Shanghai"
+	err, connectionString := m.BuildDsn(databaseConfig)
+	if err != nil {
+		panic(err)
+	}
 	return gorm.Open(postgres.Open(connectionString), &gorm.Config{})
 
 }

--- a/database/postgres_test.go
+++ b/database/postgres_test.go
@@ -1,22 +1,19 @@
 package database
 
-import
-(
+import (
 	"testing"
 )
 
 func TestPostgresInitialization(t *testing.T) {
-	env := &Env{
+	env := &DatabaseConfig{
 		DatabaseType: "postgres",
 	}
 	initializer := InitializeDatabaseDriver(env)
-	
 
 	loader := initializer.Loader
 	if l, ok := loader.(PostgresLoader); ok {
 		t.Log("TestMySqlInitialization PASSED")
 	} else {
-    	t.Errorf("TestMySqlInitialization failed. loader type is %T", l) 
+		t.Errorf("TestMySqlInitialization failed. loader type is %T", l)
 	}
 }
-

--- a/database/sqlite3.go
+++ b/database/sqlite3.go
@@ -15,6 +15,8 @@
 package database
 
 import (
+	"fmt"
+
 	"gorm.io/driver/sqlite" // Sqlite driver based on CGO
 	// "github.com/glebarez/sqlite" // Pure go SQLite driver, checkout https://github.com/glebarez/sqlite for details
 	"gorm.io/gorm"
@@ -31,8 +33,14 @@ func (m SqliteLoader) LoadDatabase(databaseConfig *DatabaseConfig) (*gorm.DB, er
 	return gorm.Open(sqlite.Open(connectionString), &gorm.Config{})
 
 }
+// For creating a SQLite Database, we're only using  its DATABASE_NAME
+// from .env file
 func (m SqliteLoader) BuildDsn(env *DatabaseConfig) (error, string) {
-	return nil, ""
+	name := env.DatabaseName
+	if len(name) == 0 {
+		return fmt.Errorf("database name cannot be empty"), ""
+	}
+	return nil, name
 }
 
 func (m SqliteLoader) BuildDsnFromEnv(path string) (error, string) {

--- a/database/sqlite3.go
+++ b/database/sqlite3.go
@@ -22,9 +22,12 @@ import (
 
 type SqliteLoader struct{}
 
-func (m SqliteLoader) LoadDatabase(connectionString string) (*gorm.DB, error) {
+func (m SqliteLoader) LoadDatabase(databaseConfig *DatabaseConfig) (*gorm.DB, error) {
 	// EXAMPLE file:test.db?cache=shared&mode=memory
-
+	err, connectionString := m.BuildDsn(databaseConfig)
+	if err != nil {
+		panic(err)
+	}
 	return gorm.Open(sqlite.Open(connectionString), &gorm.Config{})
 
 }

--- a/database/sqlite3.go
+++ b/database/sqlite3.go
@@ -15,10 +15,9 @@
 package database
 
 import (
- "gorm.io/driver/sqlite" // Sqlite driver based on CGO
-  // "github.com/glebarez/sqlite" // Pure go SQLite driver, checkout https://github.com/glebarez/sqlite for details
-  "gorm.io/gorm"
-
+	"gorm.io/driver/sqlite" // Sqlite driver based on CGO
+	// "github.com/glebarez/sqlite" // Pure go SQLite driver, checkout https://github.com/glebarez/sqlite for details
+	"gorm.io/gorm"
 )
 
 type SqliteLoader struct{}
@@ -26,14 +25,13 @@ type SqliteLoader struct{}
 func (m SqliteLoader) LoadDatabase(connectionString string) (*gorm.DB, error) {
 	// EXAMPLE file:test.db?cache=shared&mode=memory
 
-	return  gorm.Open(sqlite.Open(connectionString), &gorm.Config{})
+	return gorm.Open(sqlite.Open(connectionString), &gorm.Config{})
 
 }
-func (m SqliteLoader) BuildDsn(env *Env) (error, string) {
+func (m SqliteLoader) BuildDsn(env *DatabaseConfig) (error, string) {
 	return nil, ""
 }
 
-func (m SqliteLoader) BuildDsnFromEnv(path string)(error, string){
-		return nil, ""
+func (m SqliteLoader) BuildDsnFromEnv(path string) (error, string) {
+	return nil, ""
 }
-

--- a/database/sqlite3_test.go
+++ b/database/sqlite3_test.go
@@ -10,9 +10,12 @@ func TestSqlite3_Init(t *testing.T) {
 	os.Remove(dbPath)
 
 	env := &DatabaseConfig{
-		DatabaseType: "sqlite3",
+		DatabaseType: "sqlite",
 	}
 	initializer := InitializeDatabaseDriver(env)
+	initializer.DatabaseConfig = &DatabaseConfig{
+		DatabaseName: dbPath,
+	}
 	db := initializer.InitDatabase()
 
 	if db == nil {

--- a/database/sqlite3_test.go
+++ b/database/sqlite3_test.go
@@ -9,7 +9,7 @@ func TestSqlite3_Init(t *testing.T) {
 	dbPath := "../test.db"
 	os.Remove(dbPath)
 
-	env := &Env{
+	env := &DatabaseConfig{
 		DatabaseType: "sqlite3",
 	}
 	initializer := InitializeDatabaseDriver(env)

--- a/main.go
+++ b/main.go
@@ -10,7 +10,4 @@ import (
 
 func main()  {
 	fmt.Println("🇪🇸 🇪🇸 🇪🇸 🇪🇸  Hello World! 🇪🇸 🇪🇸 🇪🇸 🇪🇸")
-
-	
-	
 }


### PR DESCRIPTION
Workflow for initializing a database has been changed just in naming.


1. Env struct has been changed to DatabaseConfig
2. LoadDatabase has gotten rid of its method parameter. The generation of the connectionString is handled just inside the LoadDatabaseMethod throughout BuildDsn method.
